### PR TITLE
fix bug in customer email qualifier

### DIFF
--- a/ruby_scripts/common/customer_email_qualifier.rb
+++ b/ruby_scripts/common/customer_email_qualifier.rb
@@ -6,7 +6,7 @@ class CustomerEmailQualifier < Qualifier
   end
 
   def match?(cart, selector = nil)
-    return false if cart.customer.nil?
+    return false if cart.customer&.email.nil?
     customer_email = cart.customer.email
     case @match_condition
       when :match

--- a/spec/common/customer_email_qualifier_spec.rb
+++ b/spec/common/customer_email_qualifier_spec.rb
@@ -1,0 +1,112 @@
+require "./ruby_scripts/common/customer_email_qualifier"
+
+RSpec.describe CustomerEmailQualifier, "#match?" do
+  let(:customer) { nil }
+  let!(:cart) { create(:cart, customer: customer) }
+  let(:emails) { ["test@shopify.com"] }
+
+  describe "with no customer" do
+    it "returns false" do
+      expect(
+        described_class.new(
+          :does,
+          :match,
+          emails,
+        ).match?(cart)
+      ).to be(false)
+    end
+  end
+
+  describe "with a customer with no email" do
+    let(:customer) { create(:customer) }
+
+    it "returns false when using :match" do
+      expect(
+        described_class.new(
+          :does,
+          :match,
+          emails,
+        ).match?(cart)
+      ).to be(false)
+    end
+
+    it "returns false when using :include" do
+      expect(
+        described_class.new(
+          :does,
+          :include,
+          emails,
+        ).match?(cart)
+      ).to be(false)
+    end
+  end
+
+  describe "with a customer with an email" do
+    let(:customer) { create(:customer, email: emails.first) }
+
+    describe "match" do
+      it "returns false when email does not match" do
+        expect(
+          described_class.new(
+            :does,
+            :match,
+            ['test2@shopify.com'],
+          ).match?(cart)
+        ).to be(false)
+      end
+
+      it "returns true when email does match" do
+        expect(
+          described_class.new(
+            :does,
+            :match,
+            emails,
+          ).match?(cart)
+        ).to be(true)
+      end
+
+      it "using :does_not applies opposite behaviour" do
+        expect(
+          described_class.new(
+            :does_not,
+            :match,
+            emails,
+          ).match?(cart)
+        ).to be(false)
+      end
+    end
+
+    describe "include" do
+      it "returns false when email does not include anything passed in" do
+        expect(
+          described_class.new(
+            :does,
+            :include,
+            ['@somethingelse.com'],
+          ).match?(cart)
+        ).to be(false)
+      end
+
+      it "returns true when email does include something passed in" do
+        expect(
+          described_class.new(
+            :does,
+            :include,
+            ['@shopify.com'],
+          ).match?(cart)
+        ).to be(true)
+      end
+
+      it "using :does_not applies opposite behaviour" do
+        expect(
+          described_class.new(
+            :does_not,
+            :include,
+            ['@shopify.com'],
+          ).match?(cart)
+        ).to be(false)
+      end
+    end
+
+  end
+end

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,0 +1,13 @@
+require './spec/models/customer'
+
+FactoryBot.define do
+  skip_create
+
+  factory :customer do
+    transient do
+      email { nil }
+    end
+
+    after(:create) { |customer, evaluator| customer.email = evaluator.email if evaluator.email }
+  end
+end

--- a/spec/models/customer.rb
+++ b/spec/models/customer.rb
@@ -1,3 +1,3 @@
 class Customer
-
+  attr_accessor :email
 end

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -228,7 +228,7 @@ class CustomerEmailQualifier < Qualifier
   end
 
   def match?(cart, selector = nil)
-    return false if cart.customer.nil?
+    return false if cart.customer&.email.nil?
     customer_email = cart.customer.email
     case @match_condition
       when :match


### PR DESCRIPTION
Was notified of an issue where the customer can exist, but the email can be `nil` causing a script error to occur. This will fix that. Also added some tests for the class.