### PR TITLE
Add Item Price selector to line item selector

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -3,3 +3,4 @@
 --require ./spec/models/money
 --require ./ruby_scripts/common/campaign
 --require ./ruby_scripts/common/qualifier
+--require ./ruby_scripts/common/selector

--- a/ruby_scripts/common/line_item_price_selector.rb
+++ b/ruby_scripts/common/line_item_price_selector.rb
@@ -1,0 +1,15 @@
+class LineItemPriceSelector < Selector
+  def initialize(comparison_type, amount)
+    @comparison_type = comparison_type
+    @amount = Money.new(cents: amount * 100)
+  end
+
+  def match?(line_item)
+    case @comparison_type
+      when :greater_than_equal
+        line_item.variant.price >= @amount
+      when :less_than_equal
+        line_item.variant.price <= @amount
+    end
+  end
+end

--- a/spec/common/line_item_price_selector_spec.rb
+++ b/spec/common/line_item_price_selector_spec.rb
@@ -1,0 +1,80 @@
+require "./ruby_scripts/common/line_item_price_selector"
+
+RSpec.describe LineItemPriceSelector, "#match?" do
+  let(:variant) { create(:variant) }
+  let!(:line_item) { create(:line_item, variant: variant) }
+
+  describe "using :greater_than_equal" do
+    let(:behaviour) { :greater_than_equal }
+
+    describe "with a line item variant that has a lower price than passed in" do
+      it "returns false" do
+        expect(
+          described_class.new(
+            behaviour,
+            11,
+          ).match?(line_item)
+        ).to be(false)
+      end
+    end
+
+    describe "with a line item variant that has a higher price than passed in" do
+      it "returns true" do
+        expect(
+          described_class.new(
+            behaviour,
+            9,
+          ).match?(line_item)
+        ).to be(true)
+      end
+    end
+
+    describe "with a line item variant that has equal price as passed in" do
+      it "returns true" do
+        expect(
+          described_class.new(
+            behaviour,
+            10,
+          ).match?(line_item)
+        ).to be(true)
+      end
+    end
+  end
+
+  describe "using :less_than_equal" do
+    let(:behaviour) { :less_than_equal }
+
+    describe "with a line item variant that has a lower price than passed in" do
+      it "returns false" do
+        expect(
+          described_class.new(
+            behaviour,
+            11,
+          ).match?(line_item)
+        ).to be(true)
+      end
+    end
+
+    describe "with a line item variant that has a higher price than passed in" do
+      it "returns true" do
+        expect(
+          described_class.new(
+            behaviour,
+            9,
+          ).match?(line_item)
+        ).to be(false)
+      end
+    end
+
+    describe "with a line item variant that has equal price as passed in" do
+      it "returns true" do
+        expect(
+          described_class.new(
+            behaviour,
+            10,
+          ).match?(line_item)
+        ).to be(true)
+      end
+    end
+  end
+end

--- a/spec/factories/line_item.rb
+++ b/spec/factories/line_item.rb
@@ -4,15 +4,20 @@ FactoryBot.define do
   skip_create
 
   factory :line_item do
-    variant { nil }
     quantity { 1 }
     grams { 0 }
     properties { {} }
+
+    transient do
+      variant { nil }
+      original_line_price { nil }
+    end
 
     initialize_with { new(variant, quantity) }
 
     after(:create) do |line_item, evaluator|
       line_item.original_line_price = evaluator.original_line_price if evaluator.original_line_price
+      line_item.variant = evaluator.variant if evaluator.variant
     end
   end
 end

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -335,6 +335,23 @@ class GiftCardSelector < Selector
   end
 end`,
 
+  LineItemPriceSelector: `
+class LineItemPriceSelector < Selector
+  def initialize(comparison_type, amount)
+    @comparison_type = comparison_type
+    @amount = Money.new(cents: amount * 100)
+  end
+
+  def match?(line_item)
+    case @comparison_type
+      when :greater_than_equal
+        line_item.variant.price >= @amount
+      when :less_than_equal
+        line_item.variant.price <= @amount
+    end
+  end
+end`,
+
   LineItemPropertiesSelector: `
 class LineItemPropertiesSelector < Selector
   def initialize(target_properties)
@@ -979,6 +996,30 @@ const lineItemSelectors = [{
         description: "Properties must match all entered key/value pairs",
         inputFormat: "{key:text:The property's key} : {value:text:The value of the property}",
         outputFormat: '"{text}" => "{text}"'
+      }
+    }
+  },
+  {
+    value: "LineItemPriceSelector",
+    label: "Item Price",
+    description: "Selects line items if the variant price meets the condition",
+    inputs: {
+      match_condition: {
+        type: "select",
+        description: "Set how the amount is matched",
+        options: [{
+            value: "greater_than_equal",
+            label: "Greater than or equal to"
+          },
+          {
+            value: "less_than_equal",
+            label: "Less than or equal to"
+          }
+        ]
+      },
+      amount: {
+        type: "number",
+        description: "Amount in dollars"
       }
     }
   },


### PR DESCRIPTION
This adds a new `Item Price` selector to the Line Item Selectors available. It allows to check if there is an item that's variant has a price greater than or equal to or less than or equal to a specified amount. This is one of the suggestions in #8 