### PR TITLE
Revamp logic for tax discounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopify-script-creator",
   "private": true,
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Shopify Script Creator",
   "main": "index.js",
   "scripts": {

--- a/ruby_scripts/lineItem/tax_discount.rb
+++ b/ruby_scripts/lineItem/tax_discount.rb
@@ -6,8 +6,9 @@ class TaxDiscount
 
   def apply(line_item)
     calculated_tax_fraction = @amount / (100 + @amount)
-    item_tax = line_item.variant.price * calculated_tax_fraction
-    per_item_price = line_item.variant.price - item_tax
+    item_price = (line_item.line_price * (1 /line_item.quantity))
+    item_tax = item_price * calculated_tax_fraction
+    per_item_price = item_price - item_tax
     new_line_price = per_item_price * line_item.quantity
     line_item.change_line_price(new_line_price, message: @message)
   end

--- a/src/components/ChangeLogContent.js
+++ b/src/components/ChangeLogContent.js
@@ -7,7 +7,8 @@ export default function ChangeLogContent({newVersion} = props) {
       <h3 id="changelog">Change Log</h3>
 
       <ul>
-        <li>Updated the max script length to the new supported length (24,576 characters)</li>
+        <li>0.22.1 - Updated the max script length to the new supported length (24,576 characters)</li>
+        <li>0.22.2 - Changed <b>Tax Discount</b> to properly account for items that were discounted in a previous campaign instead of causing a script error</li>
       </ul>
 
       <div style={{paddingTop: '2rem'}}>

--- a/src/scripts/lineItem.js
+++ b/src/scripts/lineItem.js
@@ -505,8 +505,9 @@ class TaxDiscount
 
   def apply(line_item)
     calculated_tax_fraction = @amount / (100 + @amount)
-    item_tax = line_item.variant.price * calculated_tax_fraction
-    per_item_price = line_item.variant.price - item_tax
+    item_price = (line_item.line_price * (1 /line_item.quantity))
+    item_tax = item_price * calculated_tax_fraction
+    per_item_price = item_price - item_tax
     new_line_price = per_item_price * line_item.quantity
     line_item.change_line_price(new_line_price, message: @message)
   end

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 export default {
-  currentVersion: "0.22.1",
+  currentVersion: "0.22.2",
   minimumVersion: "0.1.0",
 }


### PR DESCRIPTION
Had a report of an error occurring in a script `new line_price must be lower than the current line_price`. 

Dug into it and the current logic for tax discounts does not play well with a previously discounted item by another campaign. It tries to set the price based on the variant price multiplied by the quantity. The variant price, however, does not get updated within the script when the line item has a discount applied. 

In this PR I'm using some math on the current `line_price` to calculate the current variant price and using that to calculate the tax discount.