### PR TITLE
Add no discount code cart qualifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopify-script-creator",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Shopify Script Creator",
   "main": "index.js",
   "scripts": {

--- a/ruby_scripts/common/no_code_qualifier.rb
+++ b/ruby_scripts/common/no_code_qualifier.rb
@@ -1,0 +1,6 @@
+class NoCodeQualifier < Qualifier
+  def match?(cart, selector = nil)
+    return true if cart.discount_code.nil?
+    false
+  end
+end

--- a/spec/common/cart_amount_qualifier_spec.rb
+++ b/spec/common/cart_amount_qualifier_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
   describe "with :cart behaviour" do
     it "includes the price of all items in the cart" do
       expect(
-        CartAmountQualifier.new(
+        described_class.new(
           :cart,
           :equal_to,
           250,
@@ -23,7 +23,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
   describe "with :item behaviour" do
     it "only counts the price of matching items" do
       expect(
-        CartAmountQualifier.new(
+        described_class.new(
           :item,
           :equal_to,
           10,
@@ -33,7 +33,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
 
     it "does not count any items when no selector is provided" do
       expect(
-        CartAmountQualifier.new(
+        described_class.new(
           :item,
           :equal_to,
           0,
@@ -48,7 +48,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
 
       it "should equal 0" do
         expect(
-          CartAmountQualifier.new(
+          described_class.new(
             :diff_cart,
             :equal_to,
             0,
@@ -62,7 +62,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
 
       it "matches when given $10 as the comparison amount to equal" do
         expect(
-          CartAmountQualifier.new(
+          described_class.new(
             :diff_cart,
             :equal_to,
             10,
@@ -77,7 +77,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
 
     it "should equal 0 with no discounts applied" do
       expect(
-        CartAmountQualifier.new(
+        described_class.new(
           :diff_item,
           :equal_to,
           0,
@@ -93,7 +93,7 @@ RSpec.describe CartAmountQualifier, "#match?" do
 
       it "matches when given $10 as the comparison amount to equal" do
         expect(
-          CartAmountQualifier.new(
+          described_class.new(
             :diff_item,
             :equal_to,
             10,

--- a/spec/common/no_code_qualifier_spec.rb
+++ b/spec/common/no_code_qualifier_spec.rb
@@ -1,0 +1,28 @@
+require "./ruby_scripts/common/no_code_qualifier"
+
+RSpec.describe NoCodeQualifier, "#match?" do
+  let(:line_items) {[
+    create(:line_item, variant: create(:variant, id: 123)),
+    create(:line_item, variant: create(:variant, :mid_priced), quantity: 3)
+  ]}
+
+  describe "with no discount code" do
+    let(:cart) { create(:cart, line_items: line_items) }
+
+    it "matches" do
+      expect(
+        described_class.new().match?(cart)
+      ).to be(true)
+    end
+  end
+
+  describe "with a discount code" do
+    let(:cart) { create(:cart, :with_fixed_discount, line_items: line_items) }
+
+    it "does not match with a discount code" do
+      expect(
+        described_class.new().match?(cart)
+      ).to be(false)
+    end
+  end
+end

--- a/spec/factories/cart.rb
+++ b/spec/factories/cart.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     line_items { nil }
     customer { nil }
     shipping_address { nil }
-    discount_code { nil }
+    cart_discount { nil }
 
     transient do
       original_price { nil }
@@ -17,12 +17,19 @@ FactoryBot.define do
       shipping_address { create(:shipping_address) }
     end
 
-    trait :with_discount_code do
-      discount_code { create(:discount_code) }
+    trait :with_fixed_discount do
+      cart_discount { create(:fixed_discount) }
     end
 
+    trait :with_percentage_discount do
+      cart_discount { create(:percentage_discount) }
+    end
 
-    initialize_with { new(line_items, customer, shipping_address, discount_code) }
+    trait :with_shipping_discount do
+      cart_discount { create(:shipping_discount) }
+    end
+
+    initialize_with { new(line_items, customer, shipping_address, cart_discount) }
 
     after(:create) { |cart, evaluator| cart.original_price = evaluator.original_price if evaluator.original_price }
   end

--- a/spec/factories/cart_discount.rb
+++ b/spec/factories/cart_discount.rb
@@ -1,0 +1,17 @@
+require './spec/models/cart_discount'
+
+FactoryBot.define do
+  factory :percentage_discount, class: CartDiscount::PercentageDiscount do
+    code { SecureRandom.alphanumeric(8) }
+    percentage { 10 }
+  end
+
+  factory :fixed_discount, class: CartDiscount::FixedDiscount do
+    code { SecureRandom.alphanumeric(8) }
+    amount { Money.new(cents: 10000) }
+  end
+
+  factory :shipping_discount, class: CartDiscount::Shipping do
+    code { SecureRandom.alphanumeric(8) }
+  end
+end

--- a/spec/models/cart_discount.rb
+++ b/spec/models/cart_discount.rb
@@ -1,13 +1,29 @@
 module CartDiscount
-  class FixedDiscount
+  class BaseDiscount
+    attr_accessor :code
 
+    def initialize
+      @rejected = false
+    end
+
+    def reject(message:)
+      @rejected = true
+      @message = message
+    end
+
+    def rejected
+      @rejected
+    end
   end
 
-  class PercentageDiscount
-
+  class FixedDiscount < BaseDiscount
+    attr_accessor :amount
   end
 
-  class Shipping
+  class PercentageDiscount < BaseDiscount
+    attr_accessor :percentage
+  end
 
+  class Shipping < BaseDiscount
   end
 end

--- a/src/components/ChangeLogContent.js
+++ b/src/components/ChangeLogContent.js
@@ -7,7 +7,7 @@ export default function ChangeLogContent({newVersion} = props) {
       <h3 id="changelog">Change Log</h3>
 
       <ul>
-        <li>0.23.0 - Added a <b>Cart Locale Qualifier</b> to the <b>Cart Qualifier</b> options.</li>
+        <li>0.24.0 - Added a <b>Cart Has No Discount Code</b> to the <b>Cart Qualifier</b> options.</li>
       </ul>
 
       <div style={{paddingTop: '2rem'}}>

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -385,6 +385,14 @@ class LocaleQualifier < Qualifier
   end
 end`,
 
+  NoCodeQualifier: `
+class NoCodeQualifier < Qualifier
+  def match?(cart, selector = nil)
+    return true if cart.discount_code.nil?
+    false
+  end
+end`,
+
   OrSelector: `
 class OrSelector
   def initialize(*conditions)
@@ -1362,6 +1370,11 @@ const cartQualifiers = [{
         description: "Enter the applicable codes"
       }
     }
+  },
+  {
+    value: "NoCodeQualifier",
+    label: "Cart Has No Discount Code",
+    description: "Checks if there is no discount code present",
   },
   {
     value: "CountryAndProvinceQualifier",

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 export default {
-  currentVersion: "0.23.0",
+  currentVersion: "0.24.0",
   minimumVersion: "0.1.0",
 }


### PR DESCRIPTION
Adds a `Cart Has No Discount Code` qualifier to the `Cart Qualifier` options

Also:
- Small refactor of CartAmountQualifier spec
- Small tweaks to the spec/factories/cart
- Made placeholder spec/models/cart_discount more functional and added factory for it