### PR TITLE
Add Rate Price Selector

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,6 +1,7 @@
 --require spec_helper
 --require test_helper
 --require ./spec/models/money
+--require ./spec/models/adjustment
 --require ./ruby_scripts/common/campaign
 --require ./ruby_scripts/common/qualifier
 --require ./ruby_scripts/common/selector

--- a/ruby_scripts/shipping/rate_price_selector.rb
+++ b/ruby_scripts/shipping/rate_price_selector.rb
@@ -1,0 +1,27 @@
+class RatePriceSelector < Selector
+  def initialize(comparison_type, amount)
+    @comparison_type = comparison_type
+    @amount = Money.new(cents: amount * 100)
+  end
+
+  def match?(shipping_rate)
+    compare_amounts(shipping_rate.price, @comparison_type, @amount)
+  end
+
+  def compare_amounts(compare, comparison_type, compare_to)
+    case comparison_type
+      when :greater_than
+        return compare > compare_to
+      when :greater_than_or_equal
+        return compare >= compare_to
+      when :less_than
+        return compare < compare_to
+      when :less_than_or_equal
+        return compare <= compare_to
+      when :equal_to
+        return compare == compare_to
+      else
+        raise "Invalid comparison type"
+    end
+  end
+end

--- a/spec/factories/shipping_rate.rb
+++ b/spec/factories/shipping_rate.rb
@@ -1,0 +1,19 @@
+require './spec/models/shipping_rate'
+
+FactoryBot.define do
+  skip_create
+
+  factory :shipping_rate do
+    code { "Gateway1" }
+    markup { "Markup" }
+    name { "Rate Name" }
+    source { "Shopify" }
+    phone_required { false }
+
+    transient do
+      price { Money.new(cents: 10_00) }
+    end
+
+    after(:create) { |rate, evaluator| rate.price = evaluator.price if evaluator.price }
+  end
+end

--- a/spec/models/adjustment.rb
+++ b/spec/models/adjustment.rb
@@ -1,0 +1,10 @@
+class Adjustment
+  attr_reader :property, :old_value, :new_value, :message
+
+  def initialize(property:, old_value:, new_value:, message:)
+    @property = property
+    @old_value = old_value
+    @new_value = new_value
+    @message = message
+  end
+end

--- a/spec/models/shipping_rate.rb
+++ b/spec/models/shipping_rate.rb
@@ -1,11 +1,16 @@
 class ShippingRate
-  attr_accessor :code, :markup, :name, :price, :source, :phone_required?
+  attr_accessor :code, :markup, :name, :price, :source, :phone_required
 
   def change_name(new_name, message:)
-
+    @name = new_name
   end
 
   def apply_discount(discount, message:)
+    new_price = @price - @discount
 
+    @adjustments ||= []
+    adjustments << Adjustment.new(property: :price, old_value: @price, new_value: new_price, message: message)
+
+    @price = new_price
   end
 end

--- a/spec/shipping/rate_price_selector_spec.rb
+++ b/spec/shipping/rate_price_selector_spec.rb
@@ -1,0 +1,163 @@
+require "./ruby_scripts/shipping/rate_price_selector"
+
+RSpec.describe RatePriceSelector, "#match?" do
+  let(:shipping_rate) { create(:shipping_rate, price: Money.new(cents: 10_00)) }
+
+  context "using greater_than" do
+    it "matches when the price is more than the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than,
+          9
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "does not match when the price is equal to the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than,
+          10
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+
+    it "does not match when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than,
+          11
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+  end
+
+  context "using greater_than_or_equal" do
+    it "matches when the price is more than the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than_or_equal,
+          9
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "matches when the price is equal to the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than_or_equal,
+          10
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "does not match when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :greater_than_or_equal,
+          11
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+  end
+
+  context "using less_than" do
+    it "matches when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :less_than,
+          11
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "matches when the price is equal to the amount specified" do
+      expect(
+        described_class.new(
+          :less_than,
+          10
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+
+    it "does not match when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :less_than,
+          9
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+  end
+
+  context "using less_than_or_equal" do
+    it "matches when the price is more than the amount specified" do
+      expect(
+        described_class.new(
+          :less_than_or_equal,
+          9
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+
+    it "matches when the price is equal to the amount specified" do
+      expect(
+        described_class.new(
+          :less_than_or_equal,
+          10
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "does not match when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :less_than_or_equal,
+          11
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+  end
+
+  context "using equal_to" do
+    it "does not match when the price is more than the amount specified" do
+      expect(
+        described_class.new(
+          :equal_to,
+          9
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+
+    it "matches when the price is equal to the amount specified" do
+      expect(
+        described_class.new(
+          :equal_to,
+          10
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+
+    it "does not match when the price is less than the amount specified" do
+      expect(
+        described_class.new(
+          :equal_to,
+          11
+        ).match?(shipping_rate)
+      ).to be(false)
+    end
+  end
+
+  context "handles decimal numbers" do
+    let(:shipping_rate) { create(:shipping_rate, price: Money.new(cents: 10_05)) }
+
+    it "matches when decimals are used" do
+      expect(
+        described_class.new(
+          :equal_to,
+          10.05
+        ).match?(shipping_rate)
+      ).to be(true)
+    end
+  end
+end

--- a/src/scripts/shipping.js
+++ b/src/scripts/shipping.js
@@ -101,6 +101,35 @@ class RateNameSelector < Selector
   end
 end`,
 
+  RatePriceSelector: `
+class RatePriceSelector < Selector
+  def initialize(comparison_type, amount)
+    @comparison_type = comparison_type
+    @amount = Money.new(cents: amount * 100)
+  end
+
+  def match?(shipping_rate)
+    compare_amounts(shipping_rate.price, @comparison_type, @amount)
+  end
+
+  def compare_amounts(compare, comparison_type, compare_to)
+    case comparison_type
+      when :greater_than
+        return compare > compare_to
+      when :greater_than_or_equal
+        return compare >= compare_to
+      when :less_than
+        return compare < compare_to
+      when :less_than_or_equal
+        return compare <= compare_to
+      when :equal_to
+        return compare == compare_to
+      else
+        raise "Invalid comparison type"
+    end
+  end
+end`,
+
   RateSourceSelector: `
 class RateSourceSelector < Selector
   def initialize(match_type, sources)
@@ -326,6 +355,38 @@ const RATE_SELECTORS = [
       rate_sources: {
         type: "array",
         description: "Applicable sources"
+      }
+    }
+  },
+  {
+    value: "RatePriceSelector",
+    label: "Rate Price",
+    description: "Matches shipping rates based on the price",
+    inputs: {
+      condition: {
+        type: "select",
+        description: "Type of comparison",
+        options: [{
+            value: "greater_than",
+            label: "Greater than"
+          },
+          {
+            value: "less_than",
+            label: "Less than"
+          },
+          {
+            value: "greater_than_or_equal",
+            label: "Greater than or equal to"
+          },
+          {
+            value: "less_than_or_equal",
+            label: "Less than or equal to"
+          },
+        ]
+      },
+      amount: {
+        type: "number",
+        description: "Amount in dollars"
       }
     }
   },


### PR DESCRIPTION
This adds a new option under the Rate Selector for Shipping Scripts to select rates by price.