### PR TITLE
Allow cart quantity limits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "rspec", "~> 3.8"
 gem "rspec_junit_formatter"

--- a/ruby_scripts/lineItem/quantity_limit.rb
+++ b/ruby_scripts/lineItem/quantity_limit.rb
@@ -21,6 +21,8 @@ class QuantityLimit < Campaign
             key = item.variant.product.id
           when :variant
             key = item.variant.id
+          when :cart
+            key = 1
         end
 
         if key

--- a/spec/lineItem/quantity_limit_spec.rb
+++ b/spec/lineItem/quantity_limit_spec.rb
@@ -1,0 +1,175 @@
+require "./ruby_scripts/lineItem/quantity_limit"
+
+RSpec.describe QuantityLimit, "#run" do
+  let(:product1) {create(:product, id: 1)}
+  let(:product2) {create(:product, id: 2)}
+  let(:line_items) {[
+    create(:line_item, variant: create(:variant, id: 1, product: product1), quantity: 2),
+    create(:line_item, variant: create(:variant, id: 2, product: product1), quantity: 2),
+    create(:line_item, variant: create(:variant, id: 3, product: product2), quantity: 3)
+  ]}
+  let(:cart) { create(:cart, line_items: line_items) }
+  let(:original_cart) { cart.dup }
+  before do
+    original_cart.line_items = cart.line_items.map(&:dup)
+  end
+
+  it "removes all items when limit is 0 and no selector is given" do
+    described_class.new(
+      :all,
+      nil,
+      nil,
+      nil,
+      :product,
+      0,
+    ).run(cart)
+
+    expect(get_total_quantity(cart.line_items)).to eq(0)
+  end
+
+  describe "limit_by :product" do
+    let(:behaviour) { :product }
+
+    describe "with a matching product" do
+      let(:selector) { TestHelper::ProductIdMatcher.new(1) }
+
+      it "limits the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          1,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(4)
+        expect(cart.line_items[0].quantity).to eq(original_cart.line_items[0].quantity - 1)
+        # Second item was removed
+        expect(cart.line_items[1].quantity).to eq(original_cart.line_items[2].quantity)
+      end
+    end
+
+    describe "with no matching product" do
+      let(:selector) { TestHelper::ProductIdMatcher.new(4) }
+
+      it "does not limit the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          1,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(get_total_quantity(original_cart.line_items))
+      end
+    end
+  end
+
+  describe "limit_by :variant" do
+    let(:behaviour) { :variant }
+
+    describe "with a matching variant" do
+      let(:selector) { TestHelper::VariantIdMatcher.new(1) }
+
+      it "limits the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          1,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(6)
+        expect(cart.line_items[0].quantity).to eq(original_cart.line_items[0].quantity - 1)
+        expect(cart.line_items[1].quantity).to eq(original_cart.line_items[1].quantity)
+        expect(cart.line_items[2].quantity).to eq(original_cart.line_items[2].quantity)
+      end
+    end
+
+    describe "with no matching variant" do
+      let(:selector) { TestHelper::VariantIdMatcher.new(4) }
+
+      it "does not limit the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          1,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(get_total_quantity(original_cart.line_items))
+      end
+    end
+  end
+
+  describe "limit_by :cart" do
+    let(:behaviour) { :cart }
+
+    describe "with a matching product" do
+      let(:selector) { TestHelper::ProductIdMatcher.new(1) }
+
+      it "limits the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          2,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(5)
+        expect(cart.line_items[0].quantity).to eq(original_cart.line_items[0].quantity)
+        # Second item was removed
+        expect(cart.line_items[1].quantity).to eq(original_cart.line_items[2].quantity)
+      end
+    end
+
+    describe "with no matching product" do
+      let(:selector) { TestHelper::ProductIdMatcher.new(4) }
+
+      it "does not limit the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          selector,
+          behaviour,
+          2,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(get_total_quantity(original_cart.line_items))
+      end
+    end
+
+    describe "without a selector" do
+      it "limits the quantity" do
+        described_class.new(
+          :all,
+          nil,
+          nil,
+          nil,
+          behaviour,
+          3,
+        ).run(cart)
+
+        expect(get_total_quantity(cart.line_items)).to eq(3)
+        expect(cart.line_items[0].quantity).to eq(original_cart.line_items[0].quantity)
+        expect(cart.line_items[1].quantity).to eq(original_cart.line_items[1].quantity - 1)
+        # Last item was removed
+      end
+    end
+
+  end
+end
+
+def get_total_quantity(line_items)
+  line_items.reduce(0) { |tot, cur| tot + cur.quantity }
+end

--- a/spec/models/line_item.rb
+++ b/spec/models/line_item.rb
@@ -9,6 +9,14 @@ class LineItem
     @line_price = @original_line_price
   end
 
+  def split(take:)
+    if take >= self.quantity
+      raise "Take cannot be greater than or equal to the current quantity"
+    end
+    self.quantity -= take
+    LineItem.new(self.variant, take)
+  end
+
   def discounted?
     @line_price < @original_line_price
   end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -24,4 +24,14 @@ module TestHelper
       @id == line_item.variant.id
     end
   end
+
+  class ProductIdMatcher
+    def initialize(id)
+      @id = id
+    end
+
+    def match?(line_item)
+      @id == line_item.variant.product.id
+    end
+  end
 end

--- a/src/components/ChangeLogContent.js
+++ b/src/components/ChangeLogContent.js
@@ -7,8 +7,8 @@ export default function ChangeLogContent({newVersion} = props) {
       <h3 id="changelog">Change Log</h3>
 
       <ul>
-        <li>0.24.0 - Added a <b>Cart Has No Discount Code</b> to the <b>Cart Qualifier</b> options.</li>
-        <li>0.25.0 - Added <b>Rate Price</b> to the shipping rate selector options.</li>
+        <li>0.26.0 - Added a <b>Limit cart</b> option to the <b>Limit by</b> options in the <b>Quantity Limit</b> campaign. This allows for limiting the quantity throughout the entire cart.
+        </li>
       </ul>
 
       <div style={{paddingTop: '2rem'}}>

--- a/src/scripts/lineItem.js
+++ b/src/scripts/lineItem.js
@@ -451,6 +451,8 @@ class QuantityLimit < Campaign
             key = item.variant.product.id
           when :variant
             key = item.variant.id
+          when :cart
+            key = 1
         end
 
         if key
@@ -971,6 +973,10 @@ const campaigns = [{
           {
             value: "variant",
             label: "Limit by variant - Maximum amount of each matching variant of a product can be purchased"
+          },
+          {
+            value: "cart",
+            label: "Limit cart - Items that match will be limited for the entire cart"
           }
         ]
       },

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 export default {
-  currentVersion: "0.25.0",
+  currentVersion: "0.26.0",
   minimumVersion: "0.1.0",
 }


### PR DESCRIPTION
This will allow limiting the entire cart to a specific quantity of items instead of just on a per line item basis.