### PR TITLE
Fix for `undefined method 'map' for nil`

### DIFF
--- a/ruby_scripts/common/campaign.rb
+++ b/ruby_scripts/common/campaign.rb
@@ -34,7 +34,10 @@ class Campaign
       end rescue nil
       if is_selector
         raise "Missing line item match type" if @li_match_type.nil?
-        cart.line_items.send(@li_match_type) { |item| qualifier.match?(item) }
+        cart.line_items.send(@li_match_type) do |item|
+          next false if item.nil?
+          qualifiers.match?(item)
+        end
       else
         qualifier.match?(cart, @line_item_selector)
       end

--- a/ruby_scripts/common/campaign.rb
+++ b/ruby_scripts/common/campaign.rb
@@ -36,7 +36,7 @@ class Campaign
         raise "Missing line item match type" if @li_match_type.nil?
         cart.line_items.send(@li_match_type) do |item|
           next false if item.nil?
-          qualifiers.match?(item)
+          qualifier.match?(item)
         end
       else
         qualifier.match?(cart, @line_item_selector)

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -55,7 +55,7 @@ class Campaign
         raise "Missing line item match type" if @li_match_type.nil?
         cart.line_items.send(@li_match_type) do |item|
           next false if item.nil?
-          qualifiers.match?(item)
+          qualifier.match?(item)
         end
       else
         qualifier.match?(cart, @line_item_selector)

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -53,7 +53,10 @@ class Campaign
       end rescue nil
       if is_selector
         raise "Missing line item match type" if @li_match_type.nil?
-        cart.line_items.send(@li_match_type) { |item| qualifier.match?(item) }
+        cart.line_items.send(@li_match_type) do |item|
+          next false if item.nil?
+          qualifiers.match?(item)
+        end
       else
         qualifier.match?(cart, @line_item_selector)
       end

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -433,7 +433,6 @@ class ProductTagSelector < Selector
   end
 
   def match?(line_item)
-    return false if line_item.nil?
     product_tags = line_item.variant.product.tags.to_a.map(&:downcase)
     case @match_condition
       when :match

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -433,6 +433,7 @@ class ProductTagSelector < Selector
   end
 
   def match?(line_item)
+    return false if line_item.nil?
     product_tags = line_item.variant.product.tags.to_a.map(&:downcase)
     case @match_condition
       when :match


### PR DESCRIPTION
Hi, thanks for this awesome project! 

I found a slight issue which caused a runtime error. We used the script creator to do a 'free gift over £x' deal, and ran into a slight but that happened seemly at random. Using Shopify's debug tools did not show any rhyme or reason for what could be causing it.

This PR is just a patch to return false instead of causing the script to panic.