### PR TITLE
fix variant sku selector when no skus

### DIFF
--- a/ruby_scripts/common/variant_sku_selector.rb
+++ b/ruby_scripts/common/variant_sku_selector.rb
@@ -6,7 +6,8 @@ class VariantSkuSelector < Selector
   end
 
   def match?(line_item)
-    variant_skus = line_item.variant.skus.to_a.map(&:downcase)
+    variant_skus = line_item.variant.skus.to_a.filter{ |sku| !sku.nil? }.map(&:downcase)
+    
     case @match_condition
       when :match
         return @invert ^ ((@skus & variant_skus).length > 0)

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -645,7 +645,8 @@ class VariantSkuSelector < Selector
   end
 
   def match?(line_item)
-    variant_skus = line_item.variant.skus.to_a.map(&:downcase)
+    variant_skus = line_item.variant.skus.to_a.filter{ |sku| !sku.nil? }.map(&:downcase)
+    
     case @match_condition
       when :match
         return @invert ^ ((@skus & variant_skus).length > 0)


### PR DESCRIPTION
Closes https://github.com/jgodson/shopify-script-creator/issues/90

If the list was empty, `map` will not execute the block. This means that there was actually an array value of `nil` somewhere in there. This change will filter those out before running `downcase` and should stop that error from happening.