### PR TITLE
fix variant sku selector v2

### DIFF
--- a/ruby_scripts/common/variant_sku_selector.rb
+++ b/ruby_scripts/common/variant_sku_selector.rb
@@ -6,7 +6,7 @@ class VariantSkuSelector < Selector
   end
 
   def match?(line_item)
-    variant_skus = line_item.variant.skus.to_a.filter{ |sku| !sku.nil? }.map(&:downcase)
+    variant_skus = line_item.variant.skus.to_a.delete_if{ |sku| sku.nil? }.map(&:downcase)
     
     case @match_condition
       when :match

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -645,7 +645,7 @@ class VariantSkuSelector < Selector
   end
 
   def match?(line_item)
-    variant_skus = line_item.variant.skus.to_a.filter{ |sku| !sku.nil? }.map(&:downcase)
+    variant_skus = line_item.variant.skus.to_a.delete_if{ |sku| sku.nil? }.map(&:downcase)
     
     case @match_condition
       when :match


### PR DESCRIPTION
To fix #90 I tried #91 with an assumption that this was an `Array`. It is actually a [List](https://help.shopify.com/en/manual/checkout-settings/script-editor/shopify-scripts#list) that does not have `filter`, so this changes it to `delete_if`, which is available. It effectively does the same thing, removing `nil` from the list so that `downcase` won't blow up if there happened to be `nil` in the list.