### PR TITLE
fix multiple PostCartAmountQualifier

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,34 +15,35 @@ GEM
     bigdecimal (3.1.7)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    diff-lcs (1.3)
+    diff-lcs (1.5.1)
     drb (2.2.1)
-    factory_bot (5.0.2)
+    factory_bot (5.2.0)
       activesupport (>= 4.2.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     minitest (5.22.3)
     mutex_m (0.2.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    rspec_junit_formatter (0.4.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby
+  x86_64-darwin-23
 
 DEPENDENCIES
   factory_bot (~> 5.0)
@@ -50,4 +51,4 @@ DEPENDENCIES
   rspec_junit_formatter
 
 BUNDLED WITH
-   2.0.1
+   2.5.9

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopify-script-creator",
   "private": true,
-  "version": "0.34.2",
+  "version": "0.34.3",
   "description": "Shopify Script Creator",
   "main": "index.js",
   "scripts": {

--- a/src/components/ChangeLogContent.js
+++ b/src/components/ChangeLogContent.js
@@ -7,7 +7,7 @@ export default function ChangeLogContent({newVersion} = props) {
       <h3 id="changelog">Change Log</h3>
 
       <ul>
-        <li>A proper <a target="_blank" rel="noreferrer noopener" href="https://github.com/jgodson/shopify-script-creator/pull/92">fix</a> for an unexpected case when the variant sku was nil. The previous fix in v0.34.1 caused a different error.</li>
+        <li>Fixed an <Link url="https://github.com/jgodson/shopify-script-creator/issues/96" external>issue</Link> where using multiple <b>Discounted Cart Subtotal (applied by scripts)</b> didn't work.</li>
       </ul>
 
       <div style={{paddingTop: '2rem'}}>

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -21,16 +21,17 @@ class Campaign
   def initialize(condition, *qualifiers)
     @condition = (condition.to_s + '?').to_sym
     @qualifiers = PostCartAmountQualifier ? [] : [] rescue qualifiers.compact
+    @post_amount_qualifiers = []
     @line_item_selector = qualifiers.last unless @line_item_selector
     qualifiers.compact.each do |qualifier|
       is_multi_select = qualifier.instance_variable_get(:@conditions).is_a?(Array)
       if is_multi_select
         qualifier.instance_variable_get(:@conditions).each do |nested_q|
-          @post_amount_qualifier = nested_q if nested_q.is_a?(PostCartAmountQualifier)
+          @post_amount_qualifiers << nested_q if nested_q.is_a?(PostCartAmountQualifier)
           @qualifiers << qualifier
         end
       else
-        @post_amount_qualifier = qualifier if qualifier.is_a?(PostCartAmountQualifier)
+        @post_amount_qualifiers << qualifier if qualifier.is_a?(PostCartAmountQualifier)
         @qualifiers << qualifier
       end
     end if @qualifiers.empty?
@@ -45,7 +46,7 @@ class Campaign
         new_item.instance_variable_set(var, val.dup) if val.respond_to?(:dup)
       end
       new_item
-    end if @post_amount_qualifier
+    end unless @post_amount_qualifiers.empty?
     @qualifiers.send(@condition) do |qualifier|
       is_selector = false
       if qualifier.is_a?(Selector) || qualifier.instance_variable_get(:@conditions).any? { |q| q.is_a?(Selector) }
@@ -71,7 +72,7 @@ class Campaign
 
   def after_run(cart)
     @discount.apply_final_discount if @discount && @discount.respond_to?(:apply_final_discount)
-    revert_changes(cart) unless @post_amount_qualifier.nil? || @post_amount_qualifier.match?(cart)
+    revert_changes(cart) unless @post_amount_qualifiers.empty? || @post_amount_qualifiers.all? { |q| q.match?(cart) }
   end
 
   def revert_changes(cart)

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 export default {
-  currentVersion: "0.34.2",
+  currentVersion: "0.34.3",
   minimumVersion: "0.1.0",
 }


### PR DESCRIPTION
Closes #96

The issue was what I described in the above issue. Only one PostCartAmountQualifier was accounted for. This ensures that all are checked after the discount is applied.

Before:
<img width="514" alt="image" src="https://github.com/jgodson/shopify-script-creator/assets/12747574/a5cf11c0-20ae-4f2c-b1c9-2eaaaf879ce1">

After:
<img width="514" alt="image" src="https://github.com/jgodson/shopify-script-creator/assets/12747574/58c9aa92-049f-452f-9088-63af5d3a2803">

And another test:
<img width="514" alt="image" src="https://github.com/jgodson/shopify-script-creator/assets/12747574/3e29e6e6-e357-4e8d-8374-ff93195feb51">
